### PR TITLE
Corrects thumbnail saving and storage

### DIFF
--- a/wistia/services/Wistia_ThumbnailService.php
+++ b/wistia/services/Wistia_ThumbnailService.php
@@ -11,9 +11,6 @@ class Wistia_ThumbnailService extends BaseApplicationComponent
 
 	public function __construct()
 	{
-		$this->absoluteCachePath = $_SERVER['DOCUMENT_ROOT'] .
-			$this->relativeCachePath;
-
 		$this->cacheDuration = craft()->plugins
 			->getPlugin('wistia')
 			->getSettings()
@@ -23,6 +20,9 @@ class Wistia_ThumbnailService extends BaseApplicationComponent
 			->getPlugin('wistia')
 			->getSettings()
 			->thumbnailPath;
+
+		$this->absoluteCachePath = $_SERVER['DOCUMENT_ROOT'] .
+			$this->relativeCachePath;
 	}
 
 	/**


### PR DESCRIPTION
The `relativeCachePath` was being referenced before it was updated, so it was storing files in the root, regardless of what you specified in the `cachePath` setting.
